### PR TITLE
Feature/add result storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
     - libmemcache-dev
     - libmemcached-dev
 install:
-  - pip install --upgrade pip
+  - pip install --upgrade pip wheel setuptools
   - make setup
   - pip install coveralls
 before_script:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,21 @@ Before installing, make sure both `memcached` and `libmemcached are installed an
 
 ## Configuration
 
+This config represents the options to store the incoming file.
+
 ```
 # MEMCACHED STORAGE OPTIONS
-MEMCACHE_STORAGE_SERVERS=['localhost:5555']  # List of memcached servers to use for keys
-STORAGE_EXPIRATION_SECONDS=120  # Expiration of entries in the memcached storage
+MEMCACHE_STORAGE_SERVERS = ['localhost:5555']  # List of memcached servers to use for keys
+STORAGE_EXPIRATION_SECONDS = 120  # Expiration of entries in the memcached storage
+```
+
+Thumbor also allows storing the processed image independent of the incoming image.
+
+```
+MEMCACHE_ITEM_SIZE_MAX = 1048576                          # 1024 * 1024 bytes which is the default item_size_max
+MEMCACHE_SKIP_STORAGE_EXCEEDING_ITEM_SIZE_MAX = False     # Not skipping can throw TooBig error
+RESULT_STORAGE_EXPIRATION_SECONDS = 120
+RESULT_STORAGE_STORES_UNSAFE = True
 ```
 
 ## Usage
@@ -25,7 +36,14 @@ Using it is as simple as configuring it in your thumbor.conf file:
 ```
 # thumbor.conf
 STORAGE = 'thumbor_memcached.storage'
+RESULT_STORAGE = 'thumbor_memcached.result_storage'
 ```
+
+## Things to note
+
+- `STORAGE` is used to cache the original incoming image, and `RESULT_STORAGE` is used to cache the processed thumbor image.
+- By default Memcached has hard limit on `item_size_max` of [1024 * 1024 Bytes](https://github.com/memcached/memcached/commit/bed5f9bba1a02ae7176a9082cfadbd7a0d194bba). This can be changed on startup.
+- The auto-discovery feature of AWS ElastiCache based Memcached is not part of the Memcached protocol standard, and hence it is not supported by the underlying `pylibmc` and `libmemcached` libraries.
 
 ## Versions
 

--- a/tests/test_result_storage.py
+++ b/tests/test_result_storage.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import hashlib
+import mock
+import time
+import traceback
+from datetime import datetime
+from unittest import TestCase
+
+from preggy import expect
+import pylibmc
+
+from thumbor_memcached.result_storage import (
+    Storage
+)
+
+class MemcacheStorageTestCase(TestCase):
+    def setUp(self, *args, **kw):
+        super(MemcacheStorageTestCase, self).setUp(*args, **kw)
+        self.memcached = pylibmc.Client(
+            ['localhost:5555'],
+            binary=True,
+            behaviors={
+                'tcp_nodelay': True,
+                'no_block': True,
+                'ketama': True
+            }
+        )
+
+        self.memcached.flush_all()
+
+        self.request_url_fixture = 'https://wikipedia.org'
+        self.context = mock.Mock(
+            config=mock.Mock(
+                MEMCACHE_STORAGE_SERVERS=[
+                    'localhost:5555',
+                ],
+                RESULT_STORAGE_EXPIRATION_SECONDS=120,
+            ),
+            request=mock.Mock(
+              url=self.request_url_fixture
+            )
+        )
+
+    def test_can_create_storage(self):
+        storage = Storage(self.context)
+        expect(storage).not_to_be_null()
+
+    def test_can_get_result_key_for_url(self):
+        storage = Storage(self.context)
+        url = 'http://www.globo.com/'
+        expected = hashlib.sha1('thumbor-result-%s' % url).hexdigest()
+        expect(storage.result_key_for(url)).to_equal(expected)
+
+    def test_can_get_timestamp_key_for_url(self):
+        storage = Storage(self.context)
+        url = 'http://www.globo.com/'
+        expected = hashlib.sha1('thumbor-result-timestamp-%s' % url).hexdigest()
+        expect(storage.timestamp_key_for(url)).to_equal(expected)
+
+    def test_can_put_data(self):
+        storage = Storage(self.context)
+        storage.put('test-data')
+        data = self.memcached.get(storage.result_key_for(self.request_url_fixture))
+        expect(data).to_equal('test-data')
+
+    def test_can_write_less_than_item_size_max(self):
+        storage = Storage(self.context)
+        test_data = 'a' * (2**19)
+        result_key = storage.result_key_for(self.request_url_fixture)
+        stored_path = storage.put(test_data)
+        expect(stored_path).to_equal(self.request_url_fixture)
+
+        data = self.memcached.get(result_key)
+        expect(data).to_equal(test_data)
+
+    def test_can_not_write_more_than_item_size_max(self):
+        storage = Storage(self.context)
+        test_data = 'a' * (2 ** 20)
+        try:
+            storage.put(test_data)
+            data = self.memcached.get(storage.result_key_for(self.request_url_fixture))
+            raise AssertionError('should have thrown TooBig error')
+        except Exception, err:
+            trace = traceback.format_exc()
+            expect('TooBig' in trace or 'TOO BIG' in trace).to_be_true()
+
+    def test_can_default_item_size_max_from_config(self):
+        ctx = mock.Mock(
+            config=mock.Mock(
+                MEMCACHE_STORAGE_SERVERS=[
+                    'localhost:5555',
+                ],
+                MEMCACHE_ITEM_SIZE_MAX=(1024 * 1024)
+            )
+        )
+        storage = Storage(ctx)
+        expect(storage.item_size_max()).to_equal(1024 * 1024)
+
+    def test_can_skip_storage_after_item_size_max(self):
+        ctx = mock.Mock(
+            config=mock.Mock(
+                MEMCACHE_STORAGE_SERVERS=[
+                    'localhost:5555',
+                ],
+                RESULT_STORAGE_EXPIRATION_SECONDS=120,
+                MEMCACHE_ITEM_SIZE_MAX=(1024 * 1024),
+                MEMCACHE_SKIP_STORAGE_EXCEEDING_ITEM_SIZE_MAX=True
+            ),
+            request=mock.Mock(
+              url=self.request_url_fixture
+            )
+        )
+        storage = Storage(ctx)
+        test_data = 'a' * (2 ** 20)
+        is_stored = storage.put(test_data)
+        expect(is_stored).to_equal(None)
+
+        does_exist = storage.exists(storage.result_key_for, self.request_url_fixture)
+        expect(does_exist).to_be_false()
+
+    def test_can_get_data(self):
+        storage = Storage(self.context)
+        self.memcached.set(storage.result_key_for(self.request_url_fixture), 'test-data')
+
+        data = storage.get().result()
+        expect(data).to_equal('test-data')
+
+    def test_can_put_and_get_data(self):
+        storage = Storage(self.context)
+        storage.put('test-data')
+        data = storage.get().result()
+        expect(data).to_equal('test-data')
+
+        does_exist = storage.exists(storage.result_key_for, self.request_url_fixture)
+        expect(does_exist).to_be_true()
+
+    def test_can_put_and_get_last_update_data(self):
+        storage = Storage(self.context)
+        test_data = 'a' * (2 ** 19)
+        pre_test_time = datetime.utcnow()
+        storage.put(test_data)
+        post_test_time = datetime.utcnow()
+
+        expect(pre_test_time < storage.last_updated() < post_test_time).to_be_true()
+        data = storage.get().result()
+        expect(data).to_equal(test_data)
+
+    def test_can_not_retrieve_deleted_files(self):
+        ctx = mock.Mock(
+            config=mock.Mock(
+                MEMCACHE_STORAGE_SERVERS=[
+                    'localhost:5555',
+                ],
+                RESULT_STORAGE_EXPIRATION_SECONDS=120,
+                MEMCACHE_ITEM_SIZE_MAX=(1024 * 1024),
+                MEMCACHE_SKIP_STORAGE_EXCEEDING_ITEM_SIZE_MAX=True
+            ),
+            request=mock.Mock(
+              url=self.request_url_fixture
+            )
+        )
+        storage = Storage(ctx)
+        storage.put('a')
+        expect(storage.get().result()).to_equal('a')
+
+        result_key = storage.result_key_for(self.request_url_fixture)
+        timestamp_key = storage.timestamp_key_for(self.request_url_fixture)
+        self.memcached.delete(result_key)
+        self.memcached.delete(timestamp_key)
+
+        expect(storage.get().result()).to_equal(None)
+        expect(storage.last_updated()).to_equal(None)

--- a/thumbor_memcached/result_storage.py
+++ b/thumbor_memcached/result_storage.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import hashlib
+import sys
+from datetime import datetime
+from json import loads, dumps
+
+import pylibmc
+
+from thumbor.result_storages import BaseStorage
+from tornado.concurrent import return_future
+from thumbor.utils import logger
+
+
+LOG_PREFIX = 'MEMCACHE_RESULT_STORAGE'
+
+class Storage(BaseStorage):
+
+    def __init__(self, context):
+        BaseStorage.__init__(self, context)
+
+        self.storage = pylibmc.Client(
+            self.context.config.MEMCACHE_STORAGE_SERVERS,
+            binary=True,
+            behaviors={
+                'tcp_nodelay': True,
+                'no_block': True,
+                'ketama': True
+            }
+        )
+
+    def get_hash(self, msg):
+        '''
+        :rettype: string
+        '''
+        msg = msg.encode('utf-8', 'replace')
+        return hashlib.sha1(msg).hexdigest()
+
+    def result_key_for(self, url):
+        '''
+        :rettype: string
+        '''
+        return self.get_hash('thumbor-result-%s' % url)
+
+    def timestamp_key_for(self, url):
+        '''
+        :rettype: string
+        '''
+        return self.get_hash('thumbor-result-timestamp-%s' % url)
+
+    def item_size_max(self):
+        '''
+        Memcache default is 1MB.
+        https://github.com/memcached/memcached/commit/bed5f9bba1a02ae7176a9082cfadbd7a0d194bba
+
+        :rettype: int
+        '''
+        return self.context.config.MEMCACHE_ITEM_SIZE_MAX
+
+    def skip_storage(self):
+        '''
+        :rettype: bool
+        '''
+        return self.context.config.MEMCACHE_SKIP_STORAGE_EXCEEDING_ITEM_SIZE_MAX
+
+    def content_size_exceeded_max(self, content_bytes):
+        '''
+        `sys.getsizeof` works great for this use case because we have a byte
+        sequence, and not a recursive nested structure. The unit of Memcache
+        `item_size_max` is also bytes.
+
+        :rettype: tuple(bool, int)
+        '''
+        content_size = sys.getsizeof(content_bytes)
+        if content_size > self.item_size_max():
+            return (True, content_size)
+
+        return (False, content_size)
+
+    def put(self, content_bytes):
+        '''
+        Save the `bytes` under a key derived from `path` in Memcache.
+
+        :return: A string representing the content path if it is stored.
+        :rettype: string or None
+        '''
+        derived_path = self.context.request.url
+        over_max, content_size = self.content_size_exceeded_max(content_bytes)
+
+        logger.debug('[{log_prefix}] content size in bytes: {size}'
+            ' | is over max? {over_max} | skip storage? {skip}'.format(
+            log_prefix=LOG_PREFIX, size=content_size, over_max=over_max,
+            skip=self.skip_storage()))
+
+        if (over_max and self.skip_storage()):
+            # Short-circuit the storage when configured to skip large items
+            logger.debug('[{log_prefix}] skipping storage: {content_size} '
+                           'exceeds item_size_max of {max_size}'.format(
+                           log_prefix=LOG_PREFIX, content_size=content_size,
+                           max_size=self.item_size_max()))
+            return None
+
+        self.storage.set(
+            self.timestamp_key_for(derived_path), datetime.utcnow(),
+            time=self.context.config.RESULT_STORAGE_EXPIRATION_SECONDS
+        )
+        self.storage.set(
+            self.result_key_for(derived_path), content_bytes,
+            time=self.context.config.RESULT_STORAGE_EXPIRATION_SECONDS
+        )
+
+        return derived_path
+
+    @return_future
+    def get(self, callback):
+        '''
+        Gets an item based on the path.
+        '''
+        derived_path = self.context.request.url
+        logger.debug('[{log_prefix}]: get.derived_path: {path}'.format(
+            log_prefix=LOG_PREFIX, path=derived_path))
+        callback(self.storage.get(self.result_key_for(derived_path)))
+
+    def last_updated(self):
+        '''
+        This is used only when SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS is eet.
+
+        :return: A DateTime object
+        :rettype: datetime.datetime
+        '''
+        derived_path = self.context.request.url
+        timestamp_key = self.timestamp_key_for(derived_path)
+
+        if self.exists(self.timestamp_key_for, derived_path):
+            return self.storage.get(timestamp_key)
+
+        return None
+
+    def exists(self, key_for, path):
+        '''
+        Check if a key for a path exists in Memcache.
+
+        :rettype: bool
+        '''
+        return self.storage.get(key_for(path)) is not None


### PR DESCRIPTION
Hi @heynemann,

Thanks for creating this great plugin! Here is a quick summary of this PR:
- Add support for result storage in Memcached. It conforms to the [result storages base](https://github.com/thumbor/thumbor/blob/master/thumbor/result_storages/__init__.py) provided by Thumbor.
- Allow users to configure the `item_size_max` for their Memcached server. By default Memcached server has a hard limit on `item_size_max` of [1024 * 1024 Bytes](https://github.com/memcached/memcached/commit/bed5f9bba1a02ae7176a9082cfadbd7a0d194bba). Any data that is stored after this, triggers a `pylibmc.TooBig` error.
- Allows users to safely skip storing files that exceed the configured `item_size_max` to prevent triggering the `TooBig` error. To keep this PR clean, I've not added the `item_size_max` check in the existing `storage.py`. I'd be happy to add it either in this PR or a separate one.
- Unit tests to cover the various result storage cases. Ran both unit tests and integration tests to make sure this change is a fully backwards compatible.
- Adds a few notes to the Readme for clarification.

Please let me know if you'd like me to update anything in this PR.