### PR TITLE
Bump version from 5.1.0 to 5.2.0

### DIFF
--- a/thumbor_memcached/version.py
+++ b/thumbor_memcached/version.py
@@ -8,4 +8,4 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2015, Bernardo Heynemann <heynemann@gmail.com>
 
-__version__ = '5.1.0'  # NOQA
+__version__ = '5.2.0'  # NOQA


### PR DESCRIPTION
Thank you for quickly reviewing and merging PR #2, @heynemann! I forgot to bump the version earlier. 

Could you please release a new version to PyPI after merging this? Soon after that I'll create a PR for both of these:
- Thumbor config docs - https://github.com/thumbor/thumbor/blob/master/docs/configuration.rst
- Apsl thumbor image - https://github.com/APSL/docker-thumbor/blob/master/thumbor/requirements.txt